### PR TITLE
feat(vuex): add vuex-persist + LocalStorage and Cookie persister

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -160,6 +160,21 @@
       "integrity": "sha1-AFLBNvUkgAJCjjY4s33ko5gYZB0=",
       "dev": true
     },
+    "@types/cookie-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.1.tgz",
+      "integrity": "sha512-iJY6B3ZGufLiDf2OCAgiAAQuj1sMKC/wz/7XCEjZ+/MDuultfFJuSwrBKcLSmJ5iYApLzCCYBYJZs0Ws8GPmwA==",
+      "dev": true,
+      "requires": {
+        "@types/express": "4.11.0"
+      }
+    },
+    "@types/deepmerge": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@types/deepmerge/-/deepmerge-1.3.3.tgz",
+      "integrity": "sha512-MobK1xxjn+OhT588IhpcGWxcNuQRZsbI3NURgdide6F8u17PWQI9GravRX51WvcKoKVgzpoi67iYdaTCv+g8MA==",
+      "dev": true
+    },
     "@types/events": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
@@ -228,6 +243,12 @@
       "version": "3.2.16",
       "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.2.16.tgz",
       "integrity": "sha512-q2WC02YxQoX2nY1HRKlYGHpGP1saPmD7GN0pwCDlTz35a4eOtJG+aHRlXyjCuXokUukSrR2aXyBhSW3j+jPc0A==",
+      "dev": true
+    },
+    "@types/js-cookie": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.1.0.tgz",
+      "integrity": "sha512-vPT5MV1pD71RFUD0ytp6Yw51W6zKJ9Qn2AcJXSD2TZqYKaXUtCxB3WZIXXFZtbAEVMgC59nmvVPSOH0EIvkaZg==",
       "dev": true
     },
     "@types/lodash": {
@@ -2639,6 +2660,15 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+    },
+    "cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha1-D+MfoZ0AC5X0qt8fU/3CuKIDuqU=",
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6"
+      }
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -8030,6 +8060,11 @@
         "mkdirp": "0.5.1",
         "nopt": "3.0.6"
       }
+    },
+    "js-cookie": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.0.tgz",
+      "integrity": "sha1-Gywnmm7s44ChIWi5JIUmWzWx7/s="
     },
     "js-tokens": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "coveragePathIgnorePatterns": [
       "/node_modules/"
     ],
+    "coverageDirectory": "../coverage",
     "testURL": "http://localhost:3000"
   },
   "config": {
@@ -125,7 +126,10 @@
     "animejs": "^2.2.0",
     "axios": "^0.17.1",
     "compression": "^1.7.1",
+    "cookie-parser": "^1.4.3",
+    "deepmerge": "^2.0.1",
     "express": "^4.16.2",
+    "js-cookie": "^2.2.0",
     "lru-cache": "^4.1.1",
     "serve-favicon": "^2.4.5",
     "vue": "^2.5.13",
@@ -138,10 +142,13 @@
   },
   "devDependencies": {
     "@types/animejs": "^2.0.0",
+    "@types/cookie-parser": "^1.4.1",
+    "@types/deepmerge": "^1.3.3",
     "@types/express": "^4.11.0",
     "@types/glob": "^5.0.34",
     "@types/html-webpack-plugin": "^2.30.1",
     "@types/jest": "^22.0.1",
+    "@types/js-cookie": "^2.1.0",
     "@types/lodash": "^4.14.92",
     "@types/node": "^8.5.7",
     "@types/serve-favicon": "^2.2.30",

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,11 +1,12 @@
 import Vue from 'vue';
 import { sync } from 'vuex-router-sync';
 import App from './App.vue';
-import { store } from './store';
+import { getStore } from './store';
 import { router } from './router';
 import { i18n } from './shared/plugins/i18n';
 import { VueRouter } from 'vue-router/types/router';
 import { Store } from 'vuex';
+import { IServerContext } from '../server/isomorphic';
 
 export interface IApp {
   app: Vue;
@@ -13,7 +14,9 @@ export interface IApp {
   store: Store<any>;
 }
 
-export const createApp = (): IApp => {
+export const createApp = (serverContext?: IServerContext): IApp => {
+  const store: Store<any> = getStore(serverContext);
+
   sync(store, router);
   const app = new Vue({
     router,

--- a/src/app/counter/Counter/Counter.vue
+++ b/src/app/counter/Counter/Counter.vue
@@ -8,7 +8,7 @@
       <vue-grid-item fill>
         <vue-button @click='increment' accent>Increment +1</vue-button>
         <vue-button @click='decrement' primary>Decrement -1</vue-button>
-        <h3>Count is {{ counter }}</h3>
+        <h3>Count is {{ counter.count }}</h3>
       </vue-grid-item>
     </vue-grid>
   </div>

--- a/src/app/counter/mutations.ts
+++ b/src/app/counter/mutations.ts
@@ -1,12 +1,14 @@
 export const counterDefaultState: any = {
-  counter: 0,
+  counter: {
+    count: 0,
+  },
 };
 
 export const counterMutations = {
   INCREMENT: (state: any) => {
-    state.counter += 1;
+    state.counter.count += 1;
   },
   DECREMENT: (state: any) => {
-    state.counter -= 1;
+    state.counter.count -= 1;
   },
 };

--- a/src/app/home/actions.ts
+++ b/src/app/home/actions.ts
@@ -1,6 +1,10 @@
 import axios from 'axios';
 
 export const getHome = ({ commit, state }: any) => {
+  if (state.home.length > 0) {
+    return commit('HOME', state.home);
+  }
+
   return axios.get('https://jsonplaceholder.typicode.com/posts').then((response: any) => {
     commit('HOME', response.data);
   });

--- a/src/app/shared/plugins/vuex/PersistCookieStorage.spec.ts
+++ b/src/app/shared/plugins/vuex/PersistCookieStorage.spec.ts
@@ -1,0 +1,97 @@
+import { PersistCookieStorage } from './PersistCookieStorage';
+import { IServerContext } from '../../../../server/isomorphic';
+
+describe('PersistCookieStorage', () => {
+  let storage: PersistCookieStorage;
+
+  beforeEach(() => {
+    storage = new PersistCookieStorage();
+  });
+
+  test('should set item', () => {
+    storage.setItem('foo', 'bar');
+
+    expect(document.cookie).toBe('vuexpersistcookie={%22vuexpersistfoo%22:%22foo%22}; vuexpersistfoo=bar');
+  });
+
+  test('should get item', () => {
+    expect(storage.getItem('foo')).toBe('bar');
+  });
+
+  test('should delete item', () => {
+    storage.removeItem('foo');
+    expect(document.cookie).toBe('vuexpersistcookie={}');
+  });
+
+  test('should clear store', () => {
+    storage.setItem('foo', 'bar');
+    storage.setItem('foo2', 'bar2');
+    storage.clear();
+
+    expect(document.cookie).toBe('');
+  });
+
+  test('key should return undefined', () => {
+    expect(storage.key(1)).toBe(undefined);
+  });
+
+  test('should merge server context if index cookie is not present', () => {
+    const mergedState: any = storage.getMergedStateFromServerContext(
+      { cookies: {} } as IServerContext,
+      {
+        foo: ['bar'],
+      },
+    );
+
+    expect(mergedState).toEqual({ foo: ['bar'] });
+  });
+
+  test('should merge server context', () => {
+    const mergedState: any = storage.getMergedStateFromServerContext(
+      {
+        cookies: {
+          vuexpersistcookie: '{"vuexpersistfoo":"foo"}',
+          vuexpersistfoo: '["baz"]',
+        },
+      } as IServerContext,
+      {
+        foo: ['bar'],
+      },
+    );
+
+    expect(mergedState).toEqual({ foo: ['baz'] });
+  });
+
+  test('should continue with invalid JSON and use initial state', () => {
+    const mergedState: any = storage.getMergedStateFromServerContext(
+      {
+        cookies: {
+          vuexpersistcookie: '{"vuexpersistfoo":"foo"}',
+          vuexpersistfoo: '["baz]',
+        },
+      } as IServerContext,
+      {
+        foo: ['bar'],
+      },
+    );
+
+    expect(mergedState).toEqual({ foo: ['bar'] });
+  });
+
+  test('should continue with invalid JSON and fall back if ther is no initial state', () => {
+    const localStorage: PersistCookieStorage = new PersistCookieStorage([], {}, 'vuexpersist');
+    const mergedState: any = localStorage.getMergedStateFromServerContext(
+      {
+        cookies: {
+          vuexpersistcookie: '{"vuexpersistfoo":"foo"}',
+          vuexpersistfoo: '["baz]',
+        },
+      } as IServerContext,
+      {
+        fooo: ['bar'],
+      },
+    );
+
+    expect(mergedState).toEqual({ fooo: ['bar'], foo: {} });
+  });
+});

--- a/src/app/shared/plugins/vuex/PersistCookieStorage.ts
+++ b/src/app/shared/plugins/vuex/PersistCookieStorage.ts
@@ -1,0 +1,98 @@
+import { IVuexPersistStorage } from './vuex-persist';
+import * as Cookies from 'js-cookie';
+import merge from 'deepmerge';
+import { IServerContext } from '../../../../server/isomorphic';
+import { CookieAttributes } from 'js-cookie';
+
+export class PersistCookieStorage implements IVuexPersistStorage {
+  public whitelist: string[];
+  public prefix: string;
+  public length: number;
+  public options: any;
+  [key: string]: any;
+  [index: number]: string;
+  private indexKey: string = 'vuexpersistcookie';
+
+  constructor(whitelist: string[] = [], options: CookieAttributes = {}, prefix: string = 'vuexpersist') {
+    this.whitelist = whitelist;
+    this.prefix = prefix;
+    this.options = options;
+  }
+
+  public clear(): void {
+    const index: any = this.getIndex();
+
+    Object.keys(index).forEach((key: string) => {
+      this.removeItem(index[key]);
+    });
+
+    Cookies.remove(this.indexKey);
+  }
+
+  public getItem(key: string): string | null {
+    return Cookies.get(this.getKey(key));
+  }
+
+  public key(index: number): string | null {
+    return undefined;
+  }
+
+  public removeItem(key: string): void {
+    this.removeFromIndex(key);
+    Cookies.remove(this.getKey(key));
+  }
+
+  public setItem(key: string, data: string): void {
+    this.addToIndex(key);
+    Cookies.set(this.getKey(key), data, this.options);
+  }
+
+  public getMergedStateFromServerContext(serverContext: IServerContext, state: any): any {
+    const vuexPersistCookie: any = JSON.parse(serverContext.cookies[this.indexKey] || '{}');
+    const cookieState: any = {};
+
+    Object.keys(serverContext.cookies).forEach((key: string) => {
+      const mappedKey: string = vuexPersistCookie[key];
+
+      if (mappedKey) {
+        try {
+          cookieState[mappedKey] = JSON.parse(serverContext.cookies[key]);
+        } catch (e) {
+          cookieState[mappedKey] = state[mappedKey] || {};
+        }
+      }
+    });
+
+    return merge(state, cookieState, {
+      clone: false,
+      arrayMerge: (initial, cookie) => {
+        return cookie;
+      },
+    });
+  }
+
+  private getKey(key: string) {
+    return `${this.prefix}${key}`;
+  }
+
+  private getIndex(): any {
+    return JSON.parse(Cookies.get(this.indexKey) || '{}');
+  }
+
+  private addToIndex(key: string) {
+    const index: any = this.getIndex();
+
+    index[this.getKey(key)] = key;
+
+    Cookies.set(this.indexKey, JSON.stringify(index), this.options);
+  }
+
+  private removeFromIndex(key: string) {
+    const index: any = this.getIndex();
+
+    delete index[this.getKey(key)];
+
+    Cookies.set(this.indexKey, JSON.stringify(index), this.options);
+  }
+
+}

--- a/src/app/shared/plugins/vuex/PersistLocalStorage.spec.ts
+++ b/src/app/shared/plugins/vuex/PersistLocalStorage.spec.ts
@@ -1,0 +1,50 @@
+import { PersistLocalStorage } from './PersistLocalStorage';
+
+describe('PersistLocalStorage', () => {
+  let storage: PersistLocalStorage;
+
+  beforeEach(() => {
+    (window as any).localStorage = {
+      clear: jest.fn(),
+      getItem: jest.fn(),
+      key: jest.fn(),
+      removeItem: jest.fn(),
+      setItem: jest.fn(),
+    };
+
+    storage = new PersistLocalStorage();
+  });
+
+  test('should clear store', () => {
+    storage.clear();
+
+    expect(window.localStorage.clear).toHaveBeenCalled();
+  });
+
+  test('should get item', () => {
+    storage.getItem('foo');
+
+    expect(window.localStorage.getItem).toHaveBeenCalledWith('vuexpersistfoo');
+  });
+
+  test('should get key', () => {
+    storage.key(1);
+
+    expect(window.localStorage.key).toHaveBeenCalledWith(1);
+  });
+
+  test('should remove item', () => {
+    storage.removeItem('foo');
+
+    expect(window.localStorage.removeItem).toHaveBeenCalledWith('vuexpersistfoo');
+  });
+
+  test('should set item and change prefix', () => {
+    const localStore: PersistLocalStorage = new PersistLocalStorage([], 'testprefix');
+
+    localStore.setItem('foo', 'bar');
+
+    expect(window.localStorage.setItem).toHaveBeenCalledWith('testprefixfoo', 'bar');
+  });
+
+});

--- a/src/app/shared/plugins/vuex/PersistLocalStorage.ts
+++ b/src/app/shared/plugins/vuex/PersistLocalStorage.ts
@@ -1,0 +1,38 @@
+import { IVuexPersistStorage } from './vuex-persist';
+
+export class PersistLocalStorage implements IVuexPersistStorage {
+  public whitelist: string[];
+  public prefix: string;
+  public length: number;
+  [key: string]: any;
+  [index: number]: string;
+
+  constructor(whitelist: string[] = [], prefix: string = 'vuexpersist') {
+    this.whitelist = whitelist;
+    this.prefix = prefix;
+  }
+
+  public clear(): void {
+    window.localStorage.clear();
+  }
+
+  public getItem(key: string): string | null {
+    return window.localStorage.getItem(this.getKey(key));
+  }
+
+  public key(index: number): string | null {
+    return window.localStorage.key(index);
+  }
+
+  public removeItem(key: string): void {
+    window.localStorage.removeItem(this.getKey(key));
+  }
+
+  public setItem(key: string, data: string): void {
+    window.localStorage.setItem(this.getKey(key), data);
+  }
+
+  private getKey(key: string) {
+    return `${this.prefix}${key}`;
+  }
+}

--- a/src/app/shared/plugins/vuex/vuex-persist.spec.ts
+++ b/src/app/shared/plugins/vuex/vuex-persist.spec.ts
@@ -1,0 +1,171 @@
+import { VuexPersist } from './vuex-persist';
+import { Plugin } from 'vuex';
+import { PersistLocalStorage } from './PersistLocalStorage';
+
+describe('vuex-persist', () => {
+
+  test('should merge state', () => {
+    (window as any).localStorage = {
+      clear: jest.fn(),
+      getItem: (key: string): string => {
+        if (key === 'vuexpersistbar') {
+          return undefined;
+        }
+
+        return '{"bar":"baz"}';
+      },
+      key: jest.fn(),
+      removeItem: jest.fn(),
+      setItem: jest.fn(),
+    };
+
+    const plugin: Plugin<any> = VuexPersist([
+      new PersistLocalStorage(['foo', 'bar']),
+    ]);
+    let mergedState: any = null;
+    let updateHandler: any = null;
+    const mockStore: any = {
+      state: {
+        initial: ['TEST'],
+      },
+      subscribe: (handler: any) => {
+        updateHandler = handler;
+      },
+      replaceState: (newState: any) => {
+        mergedState = newState;
+      },
+    };
+
+    plugin(mockStore);
+
+    updateHandler({ update: true }, { bar: { test: 1 } });
+
+    expect(mergedState).toEqual({
+      foo: {
+        bar: 'baz',
+      },
+      initial: ['TEST'],
+    });
+
+    expect((window as any).localStorage.setItem.mock.calls[1])
+      .toEqual([
+        'vuexpersistbar',
+        '{"test":1}',
+      ]);
+  });
+
+  test('should continue if store is not writable', () => {
+    (window as any).localStorage = {
+      clear: jest.fn(),
+      getItem: (): string => {
+        throw new Error();
+      },
+      key: jest.fn(),
+      removeItem: jest.fn(),
+      setItem: () => {
+        throw new Error();
+      },
+    };
+
+    const plugin: Plugin<any> = VuexPersist([
+      new PersistLocalStorage(['initial']),
+    ]);
+    let mergedState: any = null;
+    let updateHandler: any = null;
+    const mockStore: any = {
+      state: {
+        initial: ['TEST'],
+      },
+      subscribe: (handler: any) => {
+        updateHandler = handler;
+      },
+      replaceState: (newState: any) => {
+        mergedState = newState;
+      },
+    };
+
+    plugin(mockStore);
+
+    expect(mergedState).toEqual({
+      initial: ['TEST'],
+    });
+  });
+
+  test('should continue if store is not readable', () => {
+    (window as any).localStorage = {
+      clear: jest.fn(),
+      getItem: (): string => {
+        throw new Error();
+      },
+      key: jest.fn(),
+      removeItem: jest.fn(),
+      setItem: jest.fn(),
+    };
+
+    const plugin: Plugin<any> = VuexPersist([
+      new PersistLocalStorage(['initial']),
+    ]);
+    let mergedState: any = null;
+    let updateHandler: any = null;
+    const mockStore: any = {
+      state: {
+        initial: ['TEST'],
+      },
+      subscribe: (handler: any) => {
+        updateHandler = handler;
+      },
+      replaceState: (newState: any) => {
+        mergedState = newState;
+      },
+    };
+
+    plugin(mockStore);
+
+    expect(mergedState).toEqual({
+      initial: ['TEST'],
+    });
+  });
+
+  test('should merge arrays correctly', () => {
+    (window as any).localStorage = {
+      clear: jest.fn(),
+      getItem: (): string => {
+        return '["TEST"]';
+      },
+      key: jest.fn(),
+      removeItem: jest.fn(),
+      setItem: jest.fn(),
+    };
+
+    const plugin: Plugin<any> = VuexPersist([
+      new PersistLocalStorage(['initial']),
+    ]);
+    let mergedState: any = null;
+    let updateHandler: any = null;
+    const mockStore: any = {
+      state: {
+        initial: ['TEST'],
+      },
+      subscribe: (handler: any) => {
+        updateHandler = handler;
+      },
+      replaceState: (newState: any) => {
+        mergedState = newState;
+      },
+    };
+
+    plugin(mockStore);
+
+    updateHandler({ update: true }, { initial: ['foo', 'bar'] });
+
+    expect(mergedState).toEqual({
+      initial: ['TEST'],
+    });
+
+    expect((window as any).localStorage.setItem.mock.calls[1])
+      .toEqual([
+        'vuexpersistinitial',
+        '["foo","bar"]',
+      ]);
+  });
+});

--- a/src/app/shared/plugins/vuex/vuex-persist.ts
+++ b/src/app/shared/plugins/vuex/vuex-persist.ts
@@ -1,0 +1,72 @@
+/**
+ * inspired by https://github.com/robinvdvleuten/vuex-persistedstate
+ */
+
+import merge from 'deepmerge';
+import { Plugin, Store } from 'vuex';
+
+export interface IVuexPersistStorage extends Storage {
+  whitelist?: string[];
+  prefix?: string;
+}
+
+export const VuexPersist = (storages: IVuexPersistStorage[]): Plugin<any> => {
+  const canWriteStorage = (store: IVuexPersistStorage) => {
+    try {
+      store.setItem('@@', '1');
+      store.removeItem('@@');
+      return true;
+    } catch (e) {
+      return false;
+    }
+  };
+  const getState = (key: string, store: IVuexPersistStorage) => {
+    try {
+      const value = store.getItem(key);
+      return value && value !== 'undefined' ? JSON.parse(value) : undefined;
+    } catch (e) {
+      return undefined;
+    }
+  };
+  const setState = (key: string, state: string, store: IVuexPersistStorage) => {
+    return store.setItem(key, JSON.stringify(state));
+  };
+  const subscriber = (store: Store<any>) => {
+    return (handler: any) => {
+      return store.subscribe(handler);
+    };
+  };
+
+  return (vuexStore: Store<any>) => {
+    const hydratedState: any = {};
+
+    storages.forEach((storage: IVuexPersistStorage): void => {
+      if (canWriteStorage(storage)) {
+
+        storage.whitelist.forEach((key: string) => {
+          const savedState: any = getState(key, storage);
+
+          if (savedState && Object.keys(savedState).length > 0) {
+            hydratedState[key] = savedState;
+          }
+
+          subscriber(vuexStore)((mutation: any, state: any) => {
+            setState(key, state[key], storage);
+          });
+        });
+      }
+    });
+
+    /**
+     * merge saved state from store into initial store
+     */
+    const mergedState: any = merge(vuexStore.state, hydratedState, {
+      clone: false,
+      arrayMerge: (store, saved) => {
+        return saved;
+      },
+    });
+
+    vuexStore.replaceState(mergedState);
+  };
+};

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,17 +1,34 @@
+/* tslint:disable:no-console */
+
 import Vue from 'vue';
 import Vuex, { Store } from 'vuex';
+import { VuexPersist } from './shared/plugins/vuex/vuex-persist';
 import { actions } from './actions';
 import { getters } from './getters';
 import { defaultState, mutations } from './mutations';
+import { PersistLocalStorage } from './shared/plugins/vuex/PersistLocalStorage';
+import { PersistCookieStorage } from './shared/plugins/vuex/PersistCookieStorage';
+import { IServerContext } from '../server/isomorphic';
 
 Vue.use(Vuex);
 
-const inBrowser: boolean = typeof window !== 'undefined';
-const state: any = (inBrowser && window.__INITIAL_STATE__) || defaultState;
+let state: any = (CLIENT && window.__INITIAL_STATE__) || defaultState;
 
-export const store: Store<any> = new Vuex.Store({
-  state,
-  actions,
-  mutations,
-  getters,
-});
+export const getStore = (serverContext?: IServerContext): Store<any> => {
+  const persistCookieStorage: PersistCookieStorage = new PersistCookieStorage(['counter'], { expires: 365 });
+
+  if (serverContext) {
+    state = persistCookieStorage.getMergedStateFromServerContext(serverContext, state);
+  }
+
+  return new Vuex.Store({
+    state,
+    actions,
+    mutations,
+    getters,
+    plugins: [VuexPersist([
+      new PersistLocalStorage(['home']),
+      persistCookieStorage,
+    ])],
+  });
+};

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -15,10 +15,6 @@ if (PRODUCTION) {
 
 const { app, router, store }: IApp = createApp();
 
-if (window.__INITIAL_STATE__) {
-  store.replaceState(window.__INITIAL_STATE__);
-}
-
 router.onReady(() => {
   router
     .beforeResolve((to: Route, from: Route, next: any) => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -6,6 +6,7 @@ import * as Express from 'express';
 import * as favicon from 'serve-favicon';
 import { BundleRenderer } from 'vue-server-renderer';
 import { Handler, Request, Response } from 'express';
+import * as cookieParser from 'cookie-parser';
 
 const app: Express.Application = Express();
 const compression = require('compression');
@@ -43,6 +44,7 @@ if (isProd) {
 /**
  * middlewares
  */
+app.use(cookieParser());
 app.use(compression());
 
 /**
@@ -85,7 +87,7 @@ app.get('*', (req: Request, res: Response) => {
     }
   };
 
-  renderer.renderToStream({ url: req.url })
+  renderer.renderToStream({ url: req.url, cookies: req.cookies })
     .on('error', errorHandler)
     .on('end', () => console.log(`whole request: ${Date.now() - s}ms`))
     .pipe(res);

--- a/src/server/isomorphic.ts
+++ b/src/server/isomorphic.ts
@@ -1,9 +1,17 @@
 import { createApp, IApp } from '../app/app';
 import { Component } from 'vue-router/types/router';
+import merge from 'deepmerge';
 
-export default (context: any) => {
+export interface IServerContext {
+  url: string;
+  cookies: any;
+  meta?: any;
+  state?: any;
+}
+
+export default (context: IServerContext) => {
   return new Promise((resolve: any, reject: any) => {
-    const { app, router, store }: IApp = createApp();
+    const { app, router, store }: IApp = createApp(context);
 
     router.push(context.url);
 


### PR DESCRIPTION
### What is accomplished by your PR?
this PR will add a new VueX plugin to persist state. It'll also add two implementation to persist state, one is the `PersistLocalStorage` and one is `PersistCookieStorage`.

example code *store.ts*:
```
export const getStore = (serverContext?: IServerContext): Store<any> => {
  const persistCookieStorage: PersistCookieStorage = new PersistCookieStorage(['counter']);

  if (serverContext) {
    state = persistCookieStorage.getMergedStateFromServerContext(serverContext, state);
  }

  return new Vuex.Store({
    state,
    actions,
    mutations,
    getters,
    plugins: [VuexPersist([
      new PersistLocalStorage(['home']),
      persistCookieStorage,
    ])],
  });
};
```
### Is there something controversial in your PR?
nope


### Link to the Issue
#25 

# Checklist

### New Feature / Bug Fix

- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR