### PR TITLE
feat(navbar): automatically close nav bar when item is clicked

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -5,19 +5,19 @@
     <vue-nav-bar>
       <ul :class="$style.nav">
         <li>
-          <router-link to="/" exact>
+          <router-link to="/" @click.native="navBarClose" exact>
             <i class="fas fa-home" />
             <small>{{ $t('App.nav.home' /*Home*/) }}</small>
           </router-link>
         </li>
         <li>
-          <router-link to="/counter">
+          <router-link to="/counter" @click.native="navBarClose">
             <i class="fas fa-hashtag" />
             <small>{{ $t('App.nav.counter' /*Counter*/) }}</small>
           </router-link>
         </li>
         <li>
-          <router-link to="/components">
+          <router-link to="/components" @click.native="navBarClose">
             <i class="fas fa-puzzle-piece" />
             <small>{{ $t('App.nav.components' /*Components*/) }}</small>
           </router-link>
@@ -59,6 +59,7 @@
   import VueFooter             from './shared/components/VueFooter/VueFooter.vue';
   import VueNotificationStack  from './shared/components/VueNotificationStack/VueNotificationStack.vue';
   import { loadLanguageAsync } from './shared/plugins/i18n/i18n';
+  import { EventBus }          from './shared/services/EventBus';
 
   export default {
     components: {
@@ -75,7 +76,11 @@
         .catch((error: Error) => console.log(error));
 
         this.changeLang(lang);
+        this.navBarClose();
       },
+      navBarClose() {
+          EventBus.$emit('navbar.close');
+      }
     },
   };
 </script>

--- a/src/app/shared/components/VueNavBar/VueNavBar.spec.ts
+++ b/src/app/shared/components/VueNavBar/VueNavBar.spec.ts
@@ -1,6 +1,7 @@
 import { mount, createLocalVue } from '@vue/test-utils';
 import VueNavBar                 from './VueNavBar.vue';
 import $style                    from 'identity-obj-proxy';
+import { EventBus }              from '../../services/EventBus';
 
 const localVue = createLocalVue();
 
@@ -78,6 +79,30 @@ describe('VueNavBar.vue', () => {
 
     wrapper.vm.handleDocumentClick({ target: null });
     wrapper.update();
+    expect(wrapper.vm.isOpen).toBeFalsy();
+  });
+
+  test('should close navbar when close event is received', () => {
+    const wrapper: any = mount(VueNavBar, {
+      localVue,
+      mocks: { $style },
+    });
+
+    // Open the navbar to initialize:
+    expect(wrapper.vm.isOpen).toBeFalsy();
+
+    wrapper.find(`.${$style.hamburger}`).trigger('click');
+    wrapper.update();
+    expect(wrapper.vm.isOpen).toBeTruthy();
+
+    wrapper.vm.handleDocumentClick({ target: wrapper.find(`.${$style.hamburger}`).element });
+    wrapper.update();
+    expect(wrapper.vm.isOpen).toBeTruthy();
+
+    // Send the close event through the event bus:
+    EventBus.$emit('navbar.close');
+
+    // Navbar should now be closed:
     expect(wrapper.vm.isOpen).toBeFalsy();
   });
 });

--- a/src/app/shared/components/VueNavBar/VueNavBar.vue
+++ b/src/app/shared/components/VueNavBar/VueNavBar.vue
@@ -38,6 +38,7 @@
   import VueGridItem from '../VueGridItem/VueGridItem';
   import VueGridRow  from '../VueGridRow/VueGridRow';
   import VueCollapse from '../VueCollapse/VueCollapse';
+  import { EventBus } from '../../services/EventBus';
 
   export default {
     name:       'VueNavBar',
@@ -103,11 +104,15 @@
           this.isOpen = false;
         }
       },
+      handleCloseEvent() {
+        this.isOpen = false;
+      }
     },
     beforeMount() {
       window.addEventListener('scroll', this.handleScroll);
       document.addEventListener('click', this.handleDocumentClick);
       document.addEventListener('touchstart', this.handleDocumentClick);
+      EventBus.$on('navbar.close', this.handleCloseEvent);
     },
     mounted() {
       this.handleScroll();


### PR DESCRIPTION
<!--
There are two main goals in this document, depending on the nature of your PR:

- description: please tell us about your PR
- checklist: please review the checklist

To help to quickly understand the nature of your pull request,
please create a description that incorporates the following elements:
-->

### What is accomplished by your PR?
Closes the nav bar automatically once an item in is clicked.

### Is there something controversial in your PR?
I'm using a global event bus, because the VueNavBar and the items in it are in disparate components and they need a way to talk to eachother. This doesn't feel like the best way to me, but I'm a VueJS beginner, so I would love to learn the better way!

# Checklist

### New Feature / Bug Fix

- [x] Run unit tests to ensure all existing tests are still passing
- [ ] Add new passing unit tests to cover the code introduced by your PR

I have added a test, but it does not work. I can't find the element to click on to test it. Perhaps this cannot be unit tested, because it is implemented across components? Any insight into how to approach this is appreciated!

<!--
Thanks for contributing!
-->
