### PR TITLE
fix(vue-nav-bar): close nav bar on logo click

### DIFF
--- a/src/app/shared/components/VueNavBar/VueNavBar.vue
+++ b/src/app/shared/components/VueNavBar/VueNavBar.vue
@@ -7,7 +7,7 @@
     <vue-grid>
       <vue-grid-row>
         <vue-grid-item fill>
-          <router-link :to="to" exact>
+          <router-link :to="to" exact @click.native="isOpen = false">
             <img :class="$style.brand" :src="imageUrl" alt="logo" />
           </router-link>
           <button :class="hamburgerCssClasses" type="button" aria-label="menu" @click="isOpen = !isOpen">


### PR DESCRIPTION
<!--
There are two main goals in this document, depending on the nature of your PR:

- description: please tell us about your PR
- checklist: please review the checklist

To help to quickly understand the nature of your pull request,
please create a description that incorporates the following elements:
-->

### What is accomplished by your PR?
The nav bar closes when a menu item is clicked.
This change makes sure it also does when the logo (link to home) is clicked.

### Is there something controversial in your PR?
I don't expect it to be.


# Checklist

### New Feature / Bug Fix

- [ ] Run unit tests to ensure all existing tests are still passing
- [ ] Add new passing unit tests to cover the code introduced by your PR

**TODO**: I was trying to add a test like so
```javascript
  test('should close menu on logo click', () => {
    const wrapper: any = mount(VueNavBar, {
      localVue,
      stubs: ['router-link'],
    });

    wrapper.vm.isOpen = true;

    wrapper.find(`.brand`).trigger('click');

    expect(wrapper.vm.isOpen).toBeFalsy();
  });
```
but this doesn't work as the `<router-link>` is stubbed. Any pointers?

<!--
Thanks for contributing!
-->
