### PR TITLE
docs(cli): add hint for paths in names

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -65,6 +65,14 @@ press two more times `enter` and you will see that the CLI generated a few files
 
 You will also see that the CLI already referenced the new files in the necessary places: `./src/app/router.ts`, `./src/app/state.ts` and `./src/app/store.ts`.
 
+::: tip Name can include path
+The name of a `module`, `connected` or `component` can be prefixed with a path.
+
+For example `counter/MyNewComponent` will create a component inside the module `counter`.
+
+**A `connected` component for example has to be prefixed with a path because it only can live inside a module.**
+:::
+
 ## Verification
 
 Go to [http://localhost:3000/foo](http://localhost:3000/foo) and you should see the `Counter` example again (this is the default blueprint for modules).


### PR DESCRIPTION
closes #155

<!--
There are two main goals in this document, depending on the nature of your PR:

- description: please tell us about your PR
- checklist: please review the checklist

To help to quickly understand the nature of your pull request,
please create a description that incorporates the following elements:
-->

### What is accomplished by your PR?
This PR adds a hint for using a path in the name option of the generator cli

### Is there something controversial in your PR?
nope


### Link to the Issue
#155

# Checklist

### New Feature / Bug Fix

- [x] Run unit tests to ensure all existing tests are still passing
- [ ] Add new passing unit tests to cover the code introduced by your PR


<!--
Thanks for contributing!
-->
