### PR TITLE
fix(vue-modal): change overlay event listener for Firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "precommit": "concurrently \"npm run lint\" \"npm run test -- --silent\"",
     "ci": "concurrently \"npm run lint\" \"npm run test:coverage -- --runInBand\"",
-    "postci": "codecov -f ./coverage/*.json && npm run build:spa && npm run build && concurrently \"npm run build-storybook\" \"vuepress build docs\"",
+    "postci": "codecov -f ./coverage/*.json && npm run build && concurrently \"npm run build-storybook\" \"vuepress build docs\"",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },

--- a/src/app/shared/components/VueModal/VueModal.vue
+++ b/src/app/shared/components/VueModal/VueModal.vue
@@ -41,7 +41,7 @@
                 targets:    el,
                 translateY: {
                   value:      '0%',
-                  duration:   500,
+                  duration:   250,
                   elasticity: 100,
                 },
                 complete:   done,
@@ -59,7 +59,7 @@
                 targets:    el,
                 translateY: {
                   value:      '200%',
-                  duration:   500,
+                  duration:   250,
                   elasticity: 100,
                 },
                 complete() {
@@ -89,15 +89,15 @@
         overlay.style.background = '#000';
         overlay.style.opacity = '0';
         overlay.style.visibility = 'hidden';
-        overlay.style.transition = 'opacity 500ms linear';
+        overlay.style.transition = 'opacity 250ms linear';
         document.body.appendChild(overlay);
       }
 
-      document.addEventListener('click', this.handleDocumentClick);
+      document.addEventListener('mousedown', this.handleDocumentClick);
       document.addEventListener('touchstart', this.handleDocumentClick);
     },
     beforeDestroy() {
-      document.removeEventListener('click', this.handleDocumentClick);
+      document.removeEventListener('mousedown', this.handleDocumentClick);
       document.removeEventListener('touchstart', this.handleDocumentClick);
     },
   };
@@ -129,8 +129,9 @@
   }
 
   .fitContent {
-    padding: 0;
-    bottom:  initial;
+    padding:    0;
+    bottom:     initial;
+    overflow-y: hidden;
 
     @include media(tabletPortrait) {
       top:    $nav-bar-height;


### PR DESCRIPTION
fixes #203

<!--
There are two main goals in this document, depending on the nature of your PR:

- description: please tell us about your PR
- checklist: please review the checklist

To help to quickly understand the nature of your pull request,
please create a description that incorporates the following elements:
-->

### What is accomplished by your PR?
This PR fixes the modal dialog for Firefox, the solution is to use the `mousedown` event instead of the `click` event. It seems that Firefox emits events in a different order than other browsers.

### Is there something controversial in your PR?
I also removed the SPA build from the CI task to save some time in the pipeline


### Link to the Issue
#203 

# Checklist

### New Feature / Bug Fix

- [x] Run unit tests to ensure all existing tests are still passing
- [ ] Add new passing unit tests to cover the code introduced by your PR
- [ ] Add new documentation for the code introduced by your PR


<!--
Thanks for contributing!
-->
