### PR TITLE
fix: dockerfile now builds image (Fixes #214)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,5 @@ COPY --from=builder /app/package* ./
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/i18n ./i18n
 RUN npm install --only=production
-EXPOSE 3000
-CMD npm start
+EXPOSE 3001
+CMD PORT=3001 npm start

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM node:8-alpine
 ENV NODE_ENV=production
 RUN mkdir /app /app/logs
 WORKDIR /app
-COPY --from=builder package* ./
+COPY --from=builder /app/package* ./
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/i18n ./i18n
 RUN npm install --only=production

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -88,6 +88,7 @@ module.exports = {
               children: [
                 'guide/install',
                 'guide/run',
+                'guide/docker',
                 'guide/test',
                 'guide/clean-up',
                 'guide/i18n',

--- a/docs/guide/docker.md
+++ b/docs/guide/docker.md
@@ -10,13 +10,13 @@ In order to build the image run:
 
 When building is complete, you can proceed with firing up the docker container:  
 ```bash
-docker run -it --name vue-starter -p 3001:3000 vue/starter:latest
+docker run -it --name vue-starter -p 3001:3001 vue/starter:latest
 ``` 
 
 You have to wait for the message:  
 
 ```bash
-info: node server started at http://localhost:3000
+info: node server started at http://localhost:3001
 ```
 
 Docker is available at port: 3001 so a developer can have both docker and local server running at the same time  

--- a/docs/guide/docker.md
+++ b/docs/guide/docker.md
@@ -1,0 +1,24 @@
+# Run your application in docker
+
+The application can be served via docker too.  
+
+In order to build the image run:  
+ ```bash
+ docker build -t "vue/starter:latest" .
+ ``` 
+
+
+When building is complete, you can proceed with firing up the docker container:  
+```bash
+docker run -it --name vue-starter -p 3001:3000 vue/starter:latest
+``` 
+
+You have to wait for the message:  
+
+```bash
+info: node server started at http://localhost:3000
+```
+
+Docker is available at port: 3001 so a developer can have both docker and local server running at the same time  
+
+Now you know that everything works as expected, to see the `vue-starter` in action, go to [http://localhost:3001](http://localhost:3001).


### PR DESCRIPTION
<!--
There are two main goals in this document, depending on the nature of your PR:

- description: please tell us about your PR
- checklist: please review the checklist

To help to quickly understand the nature of your pull request,
please create a description that incorporates the following elements:
-->

### What is accomplished by your PR?
Dockerfile now successfully builds image

### Is there something controversial in your PR?
What do you think about the difference in the port? 3000 and 3001 are chosen so both docker and dev can be up in parallel. That creates a "false" message in the console when starting docker:
```shell
info: node server started at http://localhost:3000
```
Which is documented but nevertheless not ideal
### Link to the Issue
#214 

# Checklist

### New Feature / Bug Fix

- [x ] Run unit tests to ensure all existing tests are still passing
- [ ] Add new passing unit tests to cover the code introduced by your PR
- [x ] Add new documentation for the code introduced by your PR


<!--
Thanks for contributing!
-->
