### PR TITLE
fix(storybook): access `CLIENT` through the global namespace

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -9,7 +9,9 @@ import { CounterModule }        from './counter/module';
 
 Vue.use(Vuex);
 
-const state: IState = (CLIENT && window.__INITIAL_STATE__) || DefaultState;
+// Get CLIENT from the global namespace explicitly, to avoid errors when this file is loaded via the browser
+// (for example, while running Storybook)
+const state: IState = (global.CLIENT && window.__INITIAL_STATE__) || DefaultState;
 
 /* istanbul ignore next */
 const beforePersistLocalStorage = (localState: IState): IState => {


### PR DESCRIPTION
<!--
There are two main goals in this document, depending on the nature of your PR:

- description: please tell us about your PR
- checklist: please review the checklist

To help to quickly understand the nature of your pull request,
please create a description that incorporates the following elements:
-->

### What is accomplished by your PR?
Fixes issue #216 

### Is there something controversial in your PR?

I'm not sure this is the most robust fix, since it's unclear to me if `store.ts` can also be loaded in the browser (where the global namespace is called `window`).

If there's a good way to make this browser-and-server safe, that would be ideal, but this does seem to work okay when I tested it locally.


### Link to the Issue
https://github.com/devCrossNet/vue-starter/issues/216

# Checklist

### New Feature / Bug Fix

- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR **(code covered by existing tests)**
- [x] Add new documentation for the code introduced by your PR **(added comments in the code)**


<!--
Thanks for contributing!
-->
