### PR TITLE
feat(vue-modal): emit close event on ESC press

### DIFF
--- a/src/app/shared/components/VueModal/VueModal.spec.ts
+++ b/src/app/shared/components/VueModal/VueModal.spec.ts
@@ -1,4 +1,4 @@
-import { mount, createLocalVue } from '@vue/test-utils';
+import { createLocalVue, mount } from '@vue/test-utils';
 import VueModal                  from './VueModal.vue';
 
 const localVue = createLocalVue();
@@ -29,7 +29,7 @@ describe('VueModal.vue', () => {
     wrapper.vm.leave(wrapper.vm.$el, done);
   });
 
-  test('registers and unregisters scroll/click event', () => {
+  test('registers and unregisters scroll/click/keydown event', () => {
     document.addEventListener = jest.fn();
     document.removeEventListener = jest.fn();
 
@@ -37,11 +37,11 @@ describe('VueModal.vue', () => {
 
     wrapper.destroy();
 
-    expect(document.addEventListener).toHaveBeenCalledTimes(2);
-    expect(document.removeEventListener).toHaveBeenCalledTimes(2);
+    expect(document.addEventListener).toHaveBeenCalledTimes(3);
+    expect(document.removeEventListener).toHaveBeenCalledTimes(3);
   });
 
-  test('should open menu and close it on outside click', () => {
+  test('should close on outside click', () => {
     const wrapper: any = mount(VueModal, {
       localVue,
       slots: {
@@ -62,4 +62,19 @@ describe('VueModal.vue', () => {
     wrapper.vm.handleDocumentClick({ target: null });
     expect(wrapper.vm.$emit).toHaveBeenCalledTimes(1);
   });
+
+  test('should close on ESC press', () => {
+    const wrapper: any = mount(VueModal, {
+      localVue,
+    });
+
+    wrapper.vm.$emit = jest.fn();
+
+    wrapper.vm.handleDocumentKeyDown({ key: 'Enter' });
+    expect(wrapper.vm.$emit).toHaveBeenCalledTimes(0);
+
+    wrapper.vm.handleDocumentKeyDown({ key: 'Escape' });
+    expect(wrapper.vm.$emit).toHaveBeenCalledTimes(1);
+  });
+
 });

--- a/src/app/shared/components/VueModal/VueModal.vue
+++ b/src/app/shared/components/VueModal/VueModal.vue
@@ -73,6 +73,11 @@
           this.$emit('close');
         }
       },
+      handleDocumentKeyDown(e: KeyboardEvent) {
+        if (e.key === 'Escape') {
+          this.$emit('close');
+        }
+      },
     },
     beforeMount() {
       let overlay: HTMLElement = document.getElementById('overlay');
@@ -95,10 +100,12 @@
 
       document.addEventListener('mousedown', this.handleDocumentClick);
       document.addEventListener('touchstart', this.handleDocumentClick);
+      document.addEventListener('keydown', this.handleDocumentKeyDown);
     },
     beforeDestroy() {
       document.removeEventListener('mousedown', this.handleDocumentClick);
       document.removeEventListener('touchstart', this.handleDocumentClick);
+      document.removeEventListener('keydown', this.handleDocumentKeyDown);
     },
   };
 </script>


### PR DESCRIPTION
closes #244 

<!--
There are two main goals in this document, depending on the nature of your PR:

- description: please tell us about your PR
- checklist: please review the checklist

To help to quickly understand the nature of your pull request,
please create a description that incorporates the following elements:
-->

### What is accomplished by your PR?
This PR will add an key-press handler to the modal component which emits a close event if the ESC button was pressed.

### Is there something controversial in your PR?
nope


### Link to the Issue
#244 

# Checklist

### New Feature / Bug Fix

- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR
- [ ] Add new documentation for the code introduced by your PR


<!--
Thanks for contributing!
-->
