### PR TITLE
feat(vue-tab-group): add is-active property to pre-select tab-item

### DIFF
--- a/src/app/components/Components/Components.vue
+++ b/src/app/components/Components/Components.vue
@@ -223,7 +223,7 @@
               labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores
               et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
             </vue-tab-item>
-            <vue-tab-item title="Settings">
+            <vue-tab-item title="Settings" :is-active="true">
               et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
               Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut
               labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores

--- a/src/app/shared/components/VueTabGroup/VueTabGroup.spec.ts
+++ b/src/app/shared/components/VueTabGroup/VueTabGroup.spec.ts
@@ -58,4 +58,17 @@ describe('VueTabGroup.vue', () => {
     expect(wrapper.findAll('li').at(1).classes()).toEqual(['active']);
   });
 
+  test('should select second tab because of its properties', () => {
+    const wrapper = mount(VueTabGroup, {
+      localVue,
+      slots: {
+        default: '<vue-tab-item title="foo" /><vue-tab-item title="foo" :is-active="true" />',
+      },
+    });
+
+    expect((wrapper as any).vm.currentTab).toBe(1);
+
+    wrapper.destroy();
+  });
+
 });

--- a/src/app/shared/components/VueTabGroup/VueTabGroup.stories.ts
+++ b/src/app/shared/components/VueTabGroup/VueTabGroup.stories.ts
@@ -1,7 +1,7 @@
 import { storiesOf } from '@storybook/vue';
-import VueInfoAddon from 'storybook-addon-vue-info';
-import VueTabGroup from './VueTabGroup.vue';
-import VueTabItem from './VueTabItem/VueTabItem.vue';
+import VueInfoAddon  from 'storybook-addon-vue-info';
+import VueTabGroup   from './VueTabGroup.vue';
+import VueTabItem    from './VueTabItem/VueTabItem.vue';
 
 const story = (storiesOf('VueTabGroup', module) as any);
 
@@ -12,7 +12,7 @@ story.add('Default', () => ({
     VueTabGroup,
     VueTabItem,
   },
-  template: `
+  template:   `
 <vue-tab-group>
   <vue-tab-item title="Profile">
     Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut
@@ -22,7 +22,7 @@ story.add('Default', () => ({
     labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores
     et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
   </vue-tab-item>
-  <vue-tab-item title="Settings">
+  <vue-tab-item title="Settings" :is-active="true">
     et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
     Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut
     labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores

--- a/src/app/shared/components/VueTabGroup/VueTabGroup.vue
+++ b/src/app/shared/components/VueTabGroup/VueTabGroup.vue
@@ -47,6 +47,10 @@
       register(tab: any) {
         tab.$data.idx = this.tabs.length;
 
+        if (tab.$data.active) {
+          this.currentTab = tab.$data.idx;
+        }
+
         this.tabs.push(tab);
         this.tabHeader.push({
                               idx:   tab.$data.idx,

--- a/src/app/shared/components/VueTabGroup/VueTabItem/VueTabItem.vue
+++ b/src/app/shared/components/VueTabGroup/VueTabItem/VueTabItem.vue
@@ -16,9 +16,13 @@
   export default {
     name:     'VueTabItem',
     props:    {
-      title: {
+      title:    {
         type:     String,
         required: true,
+      },
+      isActive: {
+        type:    Boolean,
+        default: false,
       },
     },
     data(): any {
@@ -76,6 +80,8 @@
       },
     },
     created() {
+      this.active = this.isActive;
+
       if (this.$parent.register) {
         this.$parent.register(this);
       }


### PR DESCRIPTION
closes #245 

<!--
There are two main goals in this document, depending on the nature of your PR:

- description: please tell us about your PR
- checklist: please review the checklist

To help to quickly understand the nature of your pull request,
please create a description that incorporates the following elements:
-->

### What is accomplished by your PR?
This PR adds a new property `is-active` to the `vue-tab-item` component. This enables us to pre-select a tab

### Is there something controversial in your PR?
nope


### Link to the Issue
#245 

# Checklist

### New Feature / Bug Fix

- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR
- [x] Add new documentation for the code introduced by your PR


<!--
Thanks for contributing!
-->
