### PR TITLE
feat(vue-data-table): add row to scoped slot; add sortable, fitContent

### DIFF
--- a/src/app/components/Components/Components.spec.ts
+++ b/src/app/components/Components/Components.spec.ts
@@ -23,6 +23,7 @@ describe('Components.vue', () => {
     wrapper.vm.onRequest('foo', false);
     wrapper.vm.onAutocompleteChange();
     wrapper.vm.dataTableClick();
+    wrapper.vm.onDeleteRow();
 
     expect(wrapper.find('h1').text()).toBe('Components');
   });

--- a/src/app/components/Components/Components.vue
+++ b/src/app/components/Components/Components.vue
@@ -489,6 +489,10 @@
               </div>
             </template>
 
+            <template slot="actions" slot-scope="{row}">
+              <vue-button @click="onDeleteRow(row)">Delete</vue-button>
+            </template>
+
           </vue-data-table>
         </vue-grid-item>
       </vue-grid-row>
@@ -784,6 +788,10 @@
       dataTableClick(row: any) {
         // tslint:disable-next-line
         console.log(row);
+      },
+      onDeleteRow(row: any) {
+        // tslint:disable-next-line
+        alert(JSON.stringify(row));
       },
     },
   };

--- a/src/app/shared/components/VueDataTable/DataTableFixtures.ts
+++ b/src/app/shared/components/VueDataTable/DataTableFixtures.ts
@@ -11,19 +11,25 @@ export const dataTableHeaderFixture: IDataTableHeader = {
     title: 'Lastname',
   },
   age:       {
-    title:        'Age',
-    slot: 'age',
+    title: 'Age',
+    slot:  'age',
   },
   address:   {
     title: 'Address',
   },
   created:   {
-    title:        'Created',
-    slot: 'date',
+    title: 'Created',
+    slot:  'date',
   },
   updated:   {
-    title:        'Updated',
-    slot: 'date',
+    title: 'Updated',
+    slot:  'date',
+  },
+  actions:   {
+    title:      'Actions',
+    slot:       'actions',
+    sortable:   false,
+    fitContent: true,
   },
 };
 

--- a/src/app/shared/components/VueDataTable/IDataTable.ts
+++ b/src/app/shared/components/VueDataTable/IDataTable.ts
@@ -7,6 +7,8 @@ export interface IDataTableHeaderItem {
   visible?: boolean;
   sortKey?: string;
   slot?: string;
+  sortable?: boolean;
+  fitContent?: boolean;
 }
 
 export interface IComputedDataRowCell {

--- a/src/app/shared/components/VueDataTable/VueDataTable.stories.ts
+++ b/src/app/shared/components/VueDataTable/VueDataTable.stories.ts
@@ -55,3 +55,23 @@ story.add('Custom Cell Renderer', () => ({
     action: action('@onClick'),
   },
 }));
+
+story.add('Access Row', () => ({
+  i18n,
+  components: { VueDataTable },
+  data() {
+    return {
+      header: dataTableHeaderFixture,
+      data:   dataTableDataFixture,
+    };
+  },
+  template:   `<vue-data-table :header="header" :data="data" placeholder="Search" @click="action">
+  <template slot="actions" slot-scope="{row}"><button @click.stop.prevent="click(row)">delete</button></template>
+</vue-data-table>`,
+  methods:    {
+    action: action('@onClick'),
+    click(row: any) {
+      alert(JSON.stringify(row));
+    },
+  },
+}));

--- a/src/app/shared/components/VueDataTable/VueDataTable.vue
+++ b/src/app/shared/components/VueDataTable/VueDataTable.vue
@@ -1,10 +1,10 @@
 <template>
-  <div>
+  <div :class="$style.vueDataTable">
     <vue-data-table-search v-model="searchTerm"
                            v-if="showSearch"
                            :placeholder="placeholder" />
 
-    <table :class="$style.vueDataTable">
+    <table>
       <vue-data-table-header
         :columns="columns"
         :column-width="columnWidth"
@@ -18,9 +18,9 @@
             v-if="cell.visible"
             :key="idx"
             :class="$style.column"
-            :style="{flexBasis: `${columnWidth}`}">
+            :style="{width: `${columnWidth}`}">
 
-          <slot :name="cell.slot" :cell="cell">{{ cell.value }}</slot>
+          <slot :name="cell.slot" :cell="cell" :row="getRowObject(row)">{{ cell.value }}</slot>
 
         </td>
       </tr>
@@ -132,13 +132,21 @@
             header.visible = true;
           }
 
+          if (typeof header.sortable === 'undefined') {
+            header.sortable = true;
+          }
+
+          if (typeof header.fitContent === 'undefined') {
+            header.fitContent = false;
+          }
+
           header.sortKey = key;
 
           return header;
         });
       },
       columnWidth() {
-        return `${100 / this.columns.length}%`;
+        return `${100 / this.columns.filter((column: IDataTableHeaderItem) => column.fitContent === false && column.visible === true).length}%`;
       },
       rows() {
         return this.displayData.map((row: any) => {
@@ -185,14 +193,17 @@
           this.sortDirection = 'asc';
         }
       },
-      rowClick(cells: IComputedDataRowCell[]) {
+      getRowObject(cells: IComputedDataRowCell[]) {
         const row: any = {};
 
         cells.forEach((column: IComputedDataRowCell) => {
           row[column.key] = column.value;
         });
 
-        this.$emit('click', row);
+        return row;
+      },
+      rowClick(cells: IComputedDataRowCell[]) {
+        this.$emit('click', this.getRowObject(cells));
       },
       paginationClick(page: number) {
         this.currentPage = page - 1;
@@ -209,7 +220,10 @@
 
   .vueDataTable {
     overflow-x: scroll;
-    width:      100%;
+
+    table {
+      width: 100%;
+    }
   }
 
   .noResults {
@@ -221,13 +235,11 @@
   }
 
   .vueDataTableRow {
-    display:        flex;
-    flex-direction: row;
-    box-shadow:     $panel-shadow;
-    border:         1px solid $divider-color;
-    border-top:     none;
-    cursor:         pointer;
-    min-width:      600px;
+    box-shadow: $panel-shadow;
+    border:     1px solid $divider-color;
+    border-top: none;
+    cursor:     pointer;
+    min-width:  600px;
 
     &:hover {
       background: $panel-bg;
@@ -235,7 +247,6 @@
   }
 
   .column {
-    flex:         1 1 auto;
     border-right: 1px solid $divider-color;
     padding:      $space-unit $space-unit * 2;
 

--- a/src/app/shared/components/VueDataTable/VueDataTableHeader/VueDataTableHeader.spec.ts
+++ b/src/app/shared/components/VueDataTable/VueDataTableHeader/VueDataTableHeader.spec.ts
@@ -2,16 +2,17 @@ import { createLocalVue, mount } from '@vue/test-utils';
 import VueDataTableHeader        from './VueDataTableHeader.vue';
 import { IDataTableHeaderItem }  from '../IDataTable';
 import VueIconSort               from '../../icons/VueIconSort/VueIconSort.vue';
-import VueIconSortDown               from '../../icons/VueIconSortDown/VueIconSortDown.vue';
-import VueIconSortUp               from '../../icons/VueIconSortUp/VueIconSortUp.vue';
+import VueIconSortDown           from '../../icons/VueIconSortDown/VueIconSortDown.vue';
+import VueIconSortUp             from '../../icons/VueIconSortUp/VueIconSortUp.vue';
 
 const localVue = createLocalVue();
 
 describe('VueDataTableHeader.vue', () => {
   const columns: IDataTableHeaderItem[] = [
-    { title: 'foo', visible: true, sortKey: 'foo' },
-    { title: 'bar', visible: true, sortKey: 'bar' },
-    { title: 'baz', visible: true, sortKey: 'baz' },
+    { title: 'foo', visible: true, sortKey: 'foo', sortable: true },
+    { title: 'bar', visible: true, sortKey: 'bar', sortable: true },
+    { title: 'baz', visible: true, sortKey: 'baz', sortable: true },
+    { title: 'baz', visible: true, sortKey: 'baz', sortable: false },
   ];
 
   test('renders component', () => {
@@ -26,7 +27,7 @@ describe('VueDataTableHeader.vue', () => {
                           },
     );
 
-    expect(wrapper.findAll('.column')).toHaveLength(3);
+    expect(wrapper.findAll('.column')).toHaveLength(4);
     expect(wrapper.findAll(VueIconSort)).toHaveLength(3);
   });
 
@@ -77,8 +78,10 @@ describe('VueDataTableHeader.vue', () => {
                           },
     ) as any;
 
-    wrapper.vm.onClick(columns[0]);
+    wrapper.vm.onClick(columns[3]);
+    expect(wrapper.emitted('click')).toBeFalsy();
 
+    wrapper.vm.onClick(columns[0]);
     expect(wrapper.emitted('click')).toBeTruthy();
   });
 

--- a/src/app/shared/components/VueDataTable/VueDataTableHeader/VueDataTableHeader.vue
+++ b/src/app/shared/components/VueDataTable/VueDataTableHeader/VueDataTableHeader.vue
@@ -4,11 +4,16 @@
     <th v-for="(column, idx) in columns" v-if="column.visible"
         :key="idx"
         :class="$style.column"
-        :style="{flexBasis: `${columnWidth}`}"
-        @click="onClick(column)">{{ column.title }}
-      <vue-icon-sort v-if="!sortKey && !isActive(column.sortKey)" />
-      <vue-icon-sort-up v-if="isActive(column.sortKey) && sortDirection === 'asc'" />
-      <vue-icon-sort-down v-if="isActive(column.sortKey) && sortDirection === 'desc'" />
+        :style="{width: `${columnWidth}`}"
+        @click="onClick(column)">
+
+      {{ column.title }}
+
+      <div :class="$style.icons" v-if="column.sortable">
+        <vue-icon-sort v-if="!sortKey && !isActive(column.sortKey)" />
+        <vue-icon-sort-up v-if="isActive(column.sortKey) && sortDirection === 'asc'" />
+        <vue-icon-sort-down v-if="isActive(column.sortKey) && sortDirection === 'desc'" />
+      </div>
     </th>
   </tr>
   </thead>
@@ -42,7 +47,9 @@
     },
     methods:    {
       onClick(column: IDataTableHeaderItem) {
-        this.$emit('click', column);
+        if (column.sortable) {
+          this.$emit('click', column);
+        }
       },
       isActive(sortKey: string) {
         return sortKey === this.sortKey;
@@ -55,7 +62,6 @@
   @import "../../../styles";
 
   .vueDataTableHeader {
-    display:        flex;
     flex-direction: row;
     box-shadow:     $panel-shadow;
     border:         1px solid $divider-color;
@@ -65,15 +71,12 @@
     min-width:      600px;
 
     tr {
-      width:          100%;
-      display:        flex;
-      flex-direction: row;
-      min-width:      600px;
+      width:     100%;
+      min-width: 600px;
     }
   }
 
   .column {
-    flex:         1 1 auto;
     border-right: 1px solid $divider-color;
     padding:      $space-unit $space-unit * 2;
     cursor:       pointer;
@@ -91,9 +94,7 @@
     }
 
     i {
-      float:      right;
-      margin-top: $space-unit * 0.5;
-      opacity:    .3;
+      opacity: .3;
     }
 
     :global {
@@ -102,5 +103,11 @@
         opacity: 1;
       }
     }
+  }
+
+  .icons {
+    display: inline-block;
+    width:   $space-unit * 3;
+    float:   right;
   }
 </style>


### PR DESCRIPTION
closes #251, closes #252

<!--
There are two main goals in this document, depending on the nature of your PR:

- description: please tell us about your PR
- checklist: please review the checklist

To help to quickly understand the nature of your pull request,
please create a description that incorporates the following elements:
-->

### What is accomplished by your PR?
This PR will add the whole row to the scoped slot which enables users to have access to the row data inside a custom cell renderer.

it also adds two new properties to the column definition, `sortable` lets users disable the sorting and `fitContent` will remove the default width from a column so it fits the column content

### Is there something controversial in your PR?
I removed the flex layout from the table, it doesn't make sense


### Link to the Issue
- #251 
- #252 

# Checklist

### New Feature / Bug Fix

- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR
- [x] Add new documentation for the code introduced by your PR


<!--
Thanks for contributing!
-->
