### PR TITLE
fix: action typings

### DIFF
--- a/src/app/counter/actions.spec.ts
+++ b/src/app/counter/actions.spec.ts
@@ -1,11 +1,12 @@
 import { ActionContext, Commit, Dispatch }    from 'vuex';
 import MockAdapter                            from 'axios-mock-adapter';
 import { CounterDefaultState, ICounterState } from './state';
+import { IState }                             from '../state';
 import { CounterActions }                     from './actions';
 import { HttpService }                        from '../shared/services/HttpService';
 
 describe('CounterActions', () => {
-  let testContext: ActionContext<ICounterState, ICounterState>;
+  let testContext: ActionContext<ICounterState, IState>;
   let mockAxios: MockAdapter;
 
   beforeEach(() => {
@@ -13,7 +14,7 @@ describe('CounterActions', () => {
       dispatch: jest.fn() as Dispatch,
       commit:   jest.fn() as Commit,
       state:    CounterDefaultState(),
-    } as ActionContext<ICounterState, ICounterState>;
+    } as ActionContext<ICounterState, IState>;
 
     mockAxios = new MockAdapter(HttpService);
   });

--- a/src/app/counter/actions.ts
+++ b/src/app/counter/actions.ts
@@ -1,5 +1,6 @@
 import { ActionContext } from 'vuex';
 import { ICounterState } from './state';
+import { IState }        from '../state';
 import { HttpService }   from '../shared/services/HttpService';
 import { AxiosResponse } from 'axios';
 
@@ -8,13 +9,13 @@ export interface ICounterResponse {
 }
 
 export interface ICounterActions {
-  increment(context: ActionContext<ICounterState, ICounterState>): Promise<any>;
+  increment(context: ActionContext<ICounterState, IState>): Promise<any>;
 
-  decrement(context: ActionContext<ICounterState, ICounterState>): Promise<any>;
+  decrement(context: ActionContext<ICounterState, IState>): Promise<any>;
 }
 
 export const CounterActions: ICounterActions = {
-  increment({ commit, state }: ActionContext<ICounterState, ICounterState>): Promise<any> {
+  increment({ commit, state }: ActionContext<ICounterState, IState>): Promise<any> {
     commit('SET_INCREMENT_PENDING', true);
 
     return HttpService
@@ -27,7 +28,7 @@ export const CounterActions: ICounterActions = {
       commit('SET_INCREMENT_PENDING', false);
     });
   },
-  decrement({ commit, state }: ActionContext<ICounterState, ICounterState>): Promise<any> {
+  decrement({ commit, state }: ActionContext<ICounterState, IState>): Promise<any> {
     commit('SET_DECREMENT_PENDING', true);
 
     return HttpService

--- a/tools/generators/module/actions.spec.ts.hbs
+++ b/tools/generators/module/actions.spec.ts.hbs
@@ -3,9 +3,10 @@ import { HttpService }                        from '../shared/services/HttpServi
 import { ActionContext, Commit, Dispatch }    from 'vuex';
 import { {{ properCase moduleName }}Actions }                     from './actions';
 import { {{ properCase moduleName }}DefaultState, I{{ properCase moduleName }}State } from './state';
+import { IState }                             from '../state';
 
 describe('{{ properCase moduleName }}Actions', () => {
-  let testContext: ActionContext<I{{ properCase moduleName }}State, I{{ properCase moduleName }}State>;
+  let testContext: ActionContext<I{{ properCase moduleName }}State, IState>;
   let mockAxios: MockAdapter;
 
   beforeEach(() => {
@@ -13,7 +14,7 @@ describe('{{ properCase moduleName }}Actions', () => {
       dispatch: jest.fn() as Dispatch,
       commit:   jest.fn() as Commit,
       state:    {{ properCase moduleName }}DefaultState(),
-    } as ActionContext<I{{ properCase moduleName }}State, I{{ properCase moduleName }}State>;
+    } as ActionContext<I{{ properCase moduleName }}State, IState>;
 
     mockAxios = new MockAdapter(HttpService);
   });

--- a/tools/generators/module/actions.ts.hbs
+++ b/tools/generators/module/actions.ts.hbs
@@ -1,5 +1,6 @@
 import { ActionContext } from 'vuex';
 import { I{{ properCase moduleName }}State } from './state';
+import { IState }        from '../state';
 import { HttpService }   from '../shared/services/HttpService';
 import { AxiosResponse } from 'axios';
 
@@ -8,13 +9,13 @@ export interface I{{ properCase moduleName }}Response {
 }
 
 export interface I{{ properCase moduleName }}Actions {
-  increment(context: ActionContext<I{{ properCase moduleName }}State, I{{ properCase moduleName }}State>): Promise<any>;
+  increment(context: ActionContext<I{{ properCase moduleName }}State, IState>): Promise<any>;
 
-  decrement(context: ActionContext<I{{ properCase moduleName }}State, I{{ properCase moduleName }}State>): Promise<any>;
+  decrement(context: ActionContext<I{{ properCase moduleName }}State, IState>): Promise<any>;
 }
 
 export const {{ properCase moduleName }}Actions: I{{ properCase moduleName }}Actions = {
-  increment({ commit, state }: ActionContext<I{{ properCase moduleName }}State, I{{ properCase moduleName }}State>): Promise<any> {
+  increment({ commit, state }: ActionContext<I{{ properCase moduleName }}State, IState>): Promise<any> {
     commit('SET_INCREMENT_PENDING', true);
 
     return HttpService
@@ -27,7 +28,7 @@ export const {{ properCase moduleName }}Actions: I{{ properCase moduleName }}Act
       commit('SET_INCREMENT_PENDING', false);
     });
   },
-  decrement({ commit, state }: ActionContext<I{{ properCase moduleName }}State, I{{ properCase moduleName }}State>): Promise<any> {
+  decrement({ commit, state }: ActionContext<I{{ properCase moduleName }}State, IState>): Promise<any> {
     commit('SET_DECREMENT_PENDING', true);
 
     return HttpService


### PR DESCRIPTION
The ActionContext type takes two types as arguments: the module state
and the root state. In the counter example module we passed the state
twice instead which still works as we are not using the root state.

<!--
There are two main goals in this document, depending on the nature of your PR:

- description: please tell us about your PR
- checklist: please review the checklist

To help to quickly understand the nature of your pull request,
please create a description that incorporates the following elements:
-->

### What is accomplished by your PR?
Fix typings for actions to prevent running into typing issues as soon as you are using the root state.

### Is there something controversial in your PR?
Not if I got it right.

# Checklist

### New Feature / Bug Fix

- [x] Run unit tests to ensure all existing tests are still passing
- [ ] Add new passing unit tests to cover the code introduced by your PR
- [ ] Add new documentation for the code introduced by your PR


<!--
Thanks for contributing!
-->
