### PR TITLE
fix(vue-button): set fixed width for button loading

### DIFF
--- a/src/app/shared/components/VueButton/VueButton.spec.ts
+++ b/src/app/shared/components/VueButton/VueButton.spec.ts
@@ -91,4 +91,20 @@ describe('VueButton.vue', () => {
     expect(wrapper.findAll(`.pulse`)).toHaveLength(1);
   });
 
+  test('should apply fixed width when loading', () => {
+    const wrapper = mount(VueButton, {
+      localVue,
+    });
+
+    (wrapper as any).vm.$refs.button.getBoundingClientRect = () => {
+      return {
+        width: 134,
+      };
+    };
+
+    expect((wrapper as any).vm.actualWidth).toBeNull();
+    wrapper.setProps({ loading: true });
+    expect((wrapper as any).vm.actualWidth).toBe('134px');
+  });
+
 });

--- a/src/app/shared/components/VueButton/VueButton.vue
+++ b/src/app/shared/components/VueButton/VueButton.vue
@@ -3,7 +3,9 @@
     :class="cssClasses"
     :disabled="disabled"
     @click="onClick"
-    v-bind="$attrs">
+    v-bind="$attrs"
+    ref="button"
+    :style="{ width: actualWidth }">
     <slot v-if="loading === false" />
     <vue-loader v-if="loading === true" />
   </button>
@@ -81,6 +83,11 @@
         }
 
         return classes;
+      },
+      actualWidth() {
+        return (this.loading === true && this.$refs.button)
+               ? `${this.$refs.button.getBoundingClientRect().width}px`
+               : null;
       },
     },
   };


### PR DESCRIPTION
### What is accomplished by your PR?
Explicitly set the width of buttons, based on their actual initial width. This means that when you click a button & it goes into the loading state, it does not change width and appear to visually jump around on the page.

# Checklist

### New Feature / Bug Fix

- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR
- [ ] Add new documentation for the code introduced by your PR