### PR TITLE
refactor(components): remove attr from wrapper divs

### DIFF
--- a/src/app/form/FormExample/FormExample.vue
+++ b/src/app/form/FormExample/FormExample.vue
@@ -91,6 +91,7 @@
           id="acceptTerms"
           v-model="form.acceptTerms"
           label="I accept the terms"
+          validation="required"
           required />
       </vue-grid-item>
       <vue-grid-item>

--- a/src/app/shared/components/VueButton/VueButton.vue
+++ b/src/app/shared/components/VueButton/VueButton.vue
@@ -3,7 +3,6 @@
     :class="cssClasses"
     :disabled="disabled"
     @click="click"
-    v-bind="$attrs"
     ref="button"
     :style="{ width: actualWidth }">
     <slot v-if="loading === false" />

--- a/src/app/shared/components/VueCheckbox/VueCheckbox.vue
+++ b/src/app/shared/components/VueCheckbox/VueCheckbox.vue
@@ -7,6 +7,7 @@
       :checked="checked || value"
       :required="required"
       :disabled="disabled"
+      v-validate="validation"
       @change.prevent="onClick"
       v-bind="$attrs" />
     <div :class="$style.box" @click="onClick" />
@@ -15,8 +16,16 @@
 </template>
 
 <script lang="ts">
+  import { Validator } from 'vee-validate';
+
   export default {
     name:     'VueCheckbox',
+    inheritAttrs: false,
+    inject:   {
+      $validator: {
+        default: new Validator({}, {}),
+      },
+    },
     props:    {
       name:     {
         type:     String,
@@ -41,6 +50,9 @@
       required: {
         type:    Boolean,
         default: false,
+      },
+      validation:   {
+        default: '',
       },
       radio:    {
         type:    Boolean,

--- a/src/app/shared/components/VueInput/VueInput.vue
+++ b/src/app/shared/components/VueInput/VueInput.vue
@@ -32,6 +32,7 @@
 
   export default {
     name:     'VueInput',
+    inheritAttrs: false,
     inject:   {
       $validator: {
         default: new Validator({}, {}),

--- a/src/app/shared/components/VueSelect/VueSelect.vue
+++ b/src/app/shared/components/VueSelect/VueSelect.vue
@@ -33,6 +33,7 @@
 
   export default {
     name:     'VueSelect',
+    inheritAttrs: false,
     inject:   {
       $validator: {
         default: new Validator({}, {}),

--- a/src/app/shared/components/VueToggle/VueToggle.vue
+++ b/src/app/shared/components/VueToggle/VueToggle.vue
@@ -8,6 +8,7 @@
       :checked="isChecked"
       :required="required"
       :disabled="disabled"
+      v-validate="validation"
       @change.prevent="onClick"
       @focus="focus = true"
       @blur="focus = false"
@@ -24,8 +25,16 @@
 </template>
 
 <script lang="ts">
+  import { Validator } from 'vee-validate';
+
   export default {
     name:     'VueToggle',
+    inheritAttrs: false,
+    inject:   {
+      $validator: {
+        default: new Validator({}, {}),
+      },
+    },
     props:    {
       name:     {
         type:     String,
@@ -50,6 +59,9 @@
       required: {
         type:    Boolean,
         default: false,
+      },
+      validation:   {
+        default: '',
       },
       label:    {
         type:     String,


### PR DESCRIPTION
closes #286

<!--
There are two main goals in this document, depending on the nature of your PR:

- description: please tell us about your PR
- checklist: please review the checklist

To help to quickly understand the nature of your pull request,
please create a description that incorporates the following elements:
-->

### What is accomplished by your PR?
This PR disables the inheritance of attributes on input components that have a wrapper element.

I discovered an unwanted behavior when I applied tabIndex to input fields. because the tabIndex is not a prop of the input component it is handled as an attribute. Vue automatically adds attributes to the root element of a component, in this case, a `<div>`.

The right behavior is to have only one tabIndex in a component which is the Input component. I checked other components for the same error and fixed it.

### Is there something controversial in your PR?
I also added vee-validate to the checkbox and toggle component.


### Link to the Issue
#286 

# Checklist

### New Feature / Bug Fix

- [x] Run unit tests to ensure all existing tests are still passing
- [ ] Add new passing unit tests to cover the code introduced by your PR
- [ ] Add new documentation for the code introduced by your PR


<!--
Thanks for contributing!
-->
