### PR TITLE
feat(i18n): extract messages in single line conditions

### DIFF
--- a/tools/scripts/Utils.spec.ts
+++ b/tools/scripts/Utils.spec.ts
@@ -28,6 +28,7 @@ describe('Utils', () => {
     const content: string = `<div>
       {{ $t('test' /* this is a test */) }}
       {{ $t('test.test') }}
+      {{ foo === 1 ? $t('foo' /* Foo */) : $t('bar' /* bar */) }}
       {{ $t('test.foo' /* test (test) [test] test */) }}
       {{ $t('test.foo2' /* test (test) [test] test */ ) }}
       {{ $t("test.bar" /* test (test) [test] test */ ) }}
@@ -43,6 +44,8 @@ $t('components.markdown' /*
 
     expect(getTranslationsFromString(content)).toEqual([
       "$t('test' /* this is a test */)",
+      "$t('foo' /* Foo */)",
+      "$t('bar' /* bar */)",
       "$t('test.foo' /* test (test) [test] test */)",
       "$t('test.foo2' /* test (test) [test] test */ )",
       '$t("test.bar" /* test (test) [test] test */ )',

--- a/tools/scripts/Utils.ts
+++ b/tools/scripts/Utils.ts
@@ -1,5 +1,10 @@
 export const getTranslationsFromString = (content: string): RegExpMatchArray => {
-  return content.match(/\$t\([",'].*[",'].*\/\*[\r,\n, ,\S]*?\*\/.?\)/gm) || [];
+  const result = [];
+  const matches = content.match(/\$t\([",'].*[",'].*\/\*[\r,\n, ,\S]*?\*\/.?\)/gm) || [];
+
+  matches.forEach((match: string) => match.split(' : ').forEach((m: string) => result.push(m.trim())));
+
+  return result;
 };
 export const sanitizeMessage = (message: string): string => {
   const replacements: Array<{ from: string | RegExp; to: string }> = [


### PR DESCRIPTION
closes #293

<!--
There are two main goals in this document, depending on the nature of your PR:

- description: please tell us about your PR
- checklist: please review the checklist

To help to quickly understand the nature of your pull request,
please create a description that incorporates the following elements:
-->

### What is accomplished by your PR?
This PR will add the feature to `extract-i18n-messages` to parse translations that are in a single line condition. 

currently, this `{{ foo === 1 ? $t('foo' /* Foo */) : $t('bar' /* bar */) }}` 
extracts: `"foo": "Foo */) : $t('bar' /* bar"` 

with this PR it will extract: ```
"foo": "Foo",
"bar": "bar"```

### Is there something controversial in your PR?
it might not be the most scalable solution but should be good enough for now.


### Link to the Issue
#293 

# Checklist

### New Feature / Bug Fix

- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR
- [ ] Add new documentation for the code introduced by your PR


<!--
Thanks for contributing!
-->
