### PR TITLE
refactor(i18n): handle prettier formatting

### DIFF
--- a/tools/scripts/Utils.spec.ts
+++ b/tools/scripts/Utils.spec.ts
@@ -1,5 +1,38 @@
 import { getTranslationObject, getTranslationsFromString, sanitizeMessage } from './Utils';
 
+const testContent = `<div>
+      {{ $t('test' /* this is a test */) }}
+      
+      {{ $t('test.test') }}
+      
+      {{ foo === 1 ? $t('foo' /* Foo */) : $t('bar' /* bar */) }}
+      
+      {{ $t('test.foo' /* test (test) [test] test */) }}
+      
+      {{ $t('test.foo2' /* test (test) [test] test */) }}
+      
+      {{ $t("test.bar" /* test (test) [test] test */) }}
+      
+      <small>{{ $t('App.nav.counter' /* Counter */) }}</small>
+      
+      text:  this.$t('components.register.submit.notification.text', model /* We've sent an email to: {email}! */),
+      
+      $t('components.markdown' /*
+      # Markdown support\\n
+      - build on top of marked\\n
+      - server side rendering!!!\\n
+      - \`github style\` markdown
+      */)
+      
+	    {{
+        $t(
+          'key',
+          { key: value } /* key:
+      {key}? */,
+        )
+      }}      
+    </div>`;
+
 describe('Utils', () => {
   test('should remove comments, line breaks and double white spaces', () => {
     const message: string = `/*
@@ -25,49 +58,34 @@ describe('Utils', () => {
   });
 
   test('should parse translations from a string', () => {
-    const content: string = `<div>
-      {{ $t('test' /* this is a test */) }}
-      {{ $t('test.test') }}
-      {{ foo === 1 ? $t('foo' /* Foo */) : $t('bar' /* bar */) }}
-      {{ $t('test.foo' /* test (test) [test] test */) }}
-      {{ $t('test.foo2' /* test (test) [test] test */ ) }}
-      {{ $t("test.bar" /* test (test) [test] test */ ) }}
-      <small>{{ $t('App.nav.counter' /* Counter */) }}</small>
-                  text:  this.$t('components.register.submit.notification.text', model /* We've sent an email to: {email}! */),
-$t('components.markdown' /*
-# Markdown support\\n
-- build on top of marked\\n
-- server side rendering!!!\\n
-- \`github style\` markdown
-*/)
-    </div>`;
-
-    expect(getTranslationsFromString(content)).toEqual([
+    expect(getTranslationsFromString(testContent)).toEqual([
       "$t('test' /* this is a test */)",
       "$t('foo' /* Foo */)",
       "$t('bar' /* bar */)",
       "$t('test.foo' /* test (test) [test] test */)",
-      "$t('test.foo2' /* test (test) [test] test */ )",
-      '$t("test.bar" /* test (test) [test] test */ )',
+      "$t('test.foo2' /* test (test) [test] test */)",
+      '$t("test.bar" /* test (test) [test] test */)',
       "$t('App.nav.counter' /* Counter */)",
       "$t('components.register.submit.notification.text', model /* We've sent an email to: {email}! */)",
-      "$t('components.markdown' /*\n# Markdown support\\n\n- build on top of marked\\n\n- server side rendering!!!\\n\n- `github style` markdown\n*/)",
+      "$t('components.markdown' /*\n      # Markdown support\\n\n      - build on top of marked\\n\n      - server side rendering!!!\\n\n      - `github style` markdown\n      */)",
+      "$t(\n          'key',\n          { key: value } /* key:\n      {key}? */,\n        )",
     ]);
 
     expect(getTranslationsFromString('')).toEqual([]);
   });
 
   test('should get a translation object', () => {
-    const content: string = `<div>
-      {{ $t('test' /* this is a test */) }}
-      {{ $t('test.test') }}
-      {{ $t('test.foo' /* test (test) [test] test */) }}
-      {{ $t('test.foo' /* test (test) [test] test */ ) }}
-    </div>`;
-
-    expect(getTranslationObject(getTranslationsFromString(content))).toEqual({
+    expect(getTranslationObject(getTranslationsFromString(testContent))).toEqual({
+      'App.nav.counter': 'Counter',
+      bar: 'bar',
+      'components.register.submit.notification.text': "We've sent an email to: {email}!",
+      foo: 'Foo',
+      key: 'key: {key}?',
       test: 'this is a test',
       'test.foo': 'test (test) <test> test',
+      'test.foo2': 'test (test) <test> test',
+      'components.markdown':
+        '# Markdown support\\n - build on top of marked\\n - server side rendering!!!\\n - `github style` markdown',
     });
   });
 });

--- a/tools/scripts/Utils.ts
+++ b/tools/scripts/Utils.ts
@@ -1,6 +1,8 @@
 export const getTranslationsFromString = (content: string): RegExpMatchArray => {
   const result = [];
-  const matches = content.match(/\$t\([",'].*[",'].*\/\*[\r,\n, ,\S]*?\*\/.?\)/gm) || [];
+  let matches = content.match(/\$t\(.*\/\*[\S,\s]*?\*\/\)/gm) || [];
+
+  matches = matches.concat(content.match(/\$t\(\s.*\s.*\s.*\s.*\)/gm) || []);
 
   matches.forEach((match: string) => match.split(' : ').forEach((m: string) => result.push(m.trim())));
 
@@ -26,10 +28,14 @@ export const getTranslationObject = (matches: string[]): any => {
   const translations: any = {};
 
   matches.forEach((translation: string) => {
-    const id: string = translation.match(/'\S*'/)[0].replace(/[\\']/g, '');
-    const defaultMessage: string = translation.match(/\/\*[\S\s]*\*\//)[0];
+    const id = translation.match(/'\S*'/);
+    const comment = translation.match(/\/\*[\S\s]*\*\//);
+    const key = id && id[0].replace(/[\\']/g, '');
+    const value = comment && comment[0];
 
-    translations[id] = sanitizeMessage(defaultMessage);
+    if (key && value) {
+      translations[key] = sanitizeMessage(value);
+    }
   });
 
   return translations;


### PR DESCRIPTION
closes #301

<!--
There are two main goals in this document, depending on the nature of your PR:

- description: please tell us about your PR
- checklist: please review the checklist

To help to quickly understand the nature of your pull request,
please create a description that incorporates the following elements:
-->

### What is accomplished by your PR?
This PR refactors the extract-i18n-messages script to handle the new prettier formatting. All tests for 
    
    <div>
      {{ $t('test' /* this is a test */) }}

      {{ $t('test.test') }}
      
      {{ foo === 1 ? $t('foo' /* Foo */) : $t('bar' /* bar */) }}
      
      {{ $t('test.foo' /* test (test) [test] test */) }}
      
      {{ $t('test.foo2' /* test (test) [test] test */) }}
      
      {{ $t("test.bar" /* test (test) [test] test */) }}
      
      <small>{{ $t('App.nav.counter' /* Counter */) }}</small>
      
      text:  this.$t('components.register.submit.notification.text', model /* We've sent an email to: {email}! */),
      
      $t('components.markdown' /*
      # Markdown support\n
      - build on top of marked\n
      - server side rendering!!!\n
      - `github style` markdown
      */)
      
	    {{
        $t(
          'key',
          { key: value } /* key:
      {key}? */,
        )
      }}      
    </div>
are passing

### Is there something controversial in your PR?
nope 


### Link to the Issue
#301

# Checklist

### New Feature / Bug Fix

- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR
- [ ] Add new documentation for the code introduced by your PR


<!--
Thanks for contributing!
-->
