### PR TITLE
build: upgrade docker image to node:10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:8-alpine AS builder
+FROM node:10-alpine AS builder
 RUN mkdir /app
 WORKDIR /app
 COPY . .
 RUN npm install && npm run build
 
-FROM node:8-alpine
+FROM node:10-alpine
 ENV NODE_ENV=production
 RUN mkdir /app /app/logs
 WORKDIR /app


### PR DESCRIPTION
the documentation says that vue-starter requires "Node.js >= 10"


### What is accomplished by your PR?

just change the base image used to build the docker image

### Is there something controversial in your PR?

The documentation specifies that the required version of Node.js is 10+, better use ii during the build process
