### PR TITLE
feat(vue-button): support link as button

### DIFF
--- a/src/app/shared/components/VueButton/VueButton.spec.ts
+++ b/src/app/shared/components/VueButton/VueButton.spec.ts
@@ -4,149 +4,219 @@ import VueButton from './VueButton.vue';
 const localVue = createLocalVue();
 
 describe('VueButton.vue', () => {
-  test('renders component', () => {
-    const wrapper = mount<any>(VueButton, { localVue });
+  describe('Button', () => {
+    test('renders component', () => {
+      const wrapper = mount<any>(VueButton, { localVue });
 
-    expect(wrapper.findAll(`.button`)).toHaveLength(1);
-    expect(wrapper.findAll(`.active`)).toHaveLength(0);
-  });
-
-  test('should emit onClick event', () => {
-    const wrapper = mount<any>(VueButton, {
-      localVue,
+      expect(wrapper.findAll(`.button`)).toHaveLength(1);
+      expect(wrapper.findAll(`.active`)).toHaveLength(0);
     });
 
-    wrapper.find('button').trigger('click');
-    expect(wrapper.emitted().click).toBeTruthy();
-  });
+    test('should emit onClick event', () => {
+      const wrapper = mount<any>(VueButton, {
+        localVue,
+      });
 
-  test('should disable button and not emit onClick event', () => {
-    const wrapper = mount<any>(VueButton, {
-      localVue,
-      propsData: {
-        disabled: true,
-      },
+      wrapper.find('button').trigger('click');
+      expect(wrapper.emitted().click).toBeTruthy();
     });
 
-    expect(wrapper.findAll(`.disabled`)).toHaveLength(1);
+    test('should disable button and not emit onClick event', () => {
+      const wrapper = mount<any>(VueButton, {
+        localVue,
+        propsData: {
+          disabled: true,
+        },
+      });
 
-    wrapper.find('button').trigger('click');
-    expect(wrapper.emitted().click).toBeFalsy();
-  });
+      expect(wrapper.findAll(`.disabled`)).toHaveLength(1);
 
-  test('should show loader and not emit onClick event', () => {
-    const wrapper = mount<any>(VueButton, {
-      localVue,
-      propsData: {
-        loading: true,
-      },
+      wrapper.find('button').trigger('click');
+      expect(wrapper.emitted().click).toBeFalsy();
     });
 
-    wrapper.find('button').trigger('click');
-    expect(wrapper.emitted().click).toBeFalsy();
-  });
+    test('should show loader and not emit onClick event', () => {
+      const wrapper = mount<any>(VueButton, {
+        localVue,
+        propsData: {
+          loading: true,
+        },
+      });
 
-  test('should show primary color', () => {
-    const wrapper = mount<any>(VueButton, {
-      localVue,
-      propsData: {
-        color: 'primary',
-      },
+      wrapper.find('button').trigger('click');
+      expect(wrapper.emitted().click).toBeFalsy();
     });
 
-    expect(wrapper.findAll(`.primary`)).toHaveLength(1);
-  });
+    test('should show primary color', () => {
+      const wrapper = mount<any>(VueButton, {
+        localVue,
+        propsData: {
+          color: 'primary',
+        },
+      });
 
-  test('should show secondary color', () => {
-    const wrapper = mount<any>(VueButton, {
-      localVue,
-      propsData: {
-        color: 'secondary',
-      },
+      expect(wrapper.findAll(`.primary`)).toHaveLength(1);
     });
 
-    expect(wrapper.findAll(`.secondary`)).toHaveLength(1);
-  });
+    test('should show secondary color', () => {
+      const wrapper = mount<any>(VueButton, {
+        localVue,
+        propsData: {
+          color: 'secondary',
+        },
+      });
 
-  test('should show tertiary color', () => {
-    const wrapper = mount<any>(VueButton, {
-      localVue,
-      propsData: {
-        color: 'tertiary',
-      },
+      expect(wrapper.findAll(`.secondary`)).toHaveLength(1);
     });
 
-    expect(wrapper.findAll(`.tertiary`)).toHaveLength(1);
-  });
+    test('should show tertiary color', () => {
+      const wrapper = mount<any>(VueButton, {
+        localVue,
+        propsData: {
+          color: 'tertiary',
+        },
+      });
 
-  test('should show danger color', () => {
-    const wrapper = mount<any>(VueButton, {
-      localVue,
-      propsData: {
-        color: 'danger',
-      },
+      expect(wrapper.findAll(`.tertiary`)).toHaveLength(1);
     });
 
-    expect(wrapper.findAll(`.danger`)).toHaveLength(1);
-  });
+    test('should show danger color', () => {
+      const wrapper = mount<any>(VueButton, {
+        localVue,
+        propsData: {
+          color: 'danger',
+        },
+      });
 
-  test('should show warning color', () => {
-    const wrapper = mount<any>(VueButton, {
-      localVue,
-      propsData: {
-        color: 'warning',
-      },
+      expect(wrapper.findAll(`.danger`)).toHaveLength(1);
     });
 
-    expect(wrapper.findAll(`.warning`)).toHaveLength(1);
-  });
+    test('should show warning color', () => {
+      const wrapper = mount<any>(VueButton, {
+        localVue,
+        propsData: {
+          color: 'warning',
+        },
+      });
 
-  test('should show success color', () => {
-    const wrapper = mount<any>(VueButton, {
-      localVue,
-      propsData: {
-        color: 'success',
-      },
+      expect(wrapper.findAll(`.warning`)).toHaveLength(1);
     });
 
-    expect(wrapper.findAll(`.success`)).toHaveLength(1);
-  });
+    test('should show success color', () => {
+      const wrapper = mount<any>(VueButton, {
+        localVue,
+        propsData: {
+          color: 'success',
+        },
+      });
 
-  test('should show outlined color', () => {
-    const wrapper = mount<any>(VueButton, {
-      localVue,
-      propsData: {
-        outlined: true,
-      },
+      expect(wrapper.findAll(`.success`)).toHaveLength(1);
     });
 
-    expect(wrapper.findAll(`.outlined`)).toHaveLength(1);
-  });
+    test('should show outlined color', () => {
+      const wrapper = mount<any>(VueButton, {
+        localVue,
+        propsData: {
+          outlined: true,
+        },
+      });
 
-  test('should show ghost color', () => {
-    const wrapper = mount<any>(VueButton, {
-      localVue,
-      propsData: {
-        ghost: true,
-      },
+      expect(wrapper.findAll(`.outlined`)).toHaveLength(1);
     });
 
-    expect(wrapper.findAll(`.ghost`)).toHaveLength(1);
-  });
+    test('should show ghost color', () => {
+      const wrapper = mount<any>(VueButton, {
+        localVue,
+        propsData: {
+          ghost: true,
+        },
+      });
 
-  test('should apply fixed width when loading', () => {
-    const wrapper = mount<any>(VueButton, {
-      localVue,
+      expect(wrapper.findAll(`.ghost`)).toHaveLength(1);
     });
 
-    (wrapper as any).vm.$refs.button.getBoundingClientRect = () => {
-      return {
-        width: 134,
+    test('should apply fixed width when loading', () => {
+      const wrapper = mount<any>(VueButton, {
+        localVue,
+      });
+
+      (wrapper as any).vm.$refs.button.getBoundingClientRect = () => {
+        return {
+          width: 134,
+        };
       };
-    };
 
-    expect(wrapper.vm.actualWidth).toBeNull();
-    wrapper.setProps({ loading: true });
-    expect(wrapper.vm.actualWidth).toBe('134px');
+      expect(wrapper.vm.actualWidth).toBeNull();
+      wrapper.setProps({ loading: true });
+      expect(wrapper.vm.actualWidth).toBe('134px');
+    });
+  });
+
+  describe('Link', () => {
+    test('renders router-link', () => {
+      const wrapper = mount<any>(VueButton, {
+        localVue,
+        propsData: {
+          as: 'router-link',
+          to: '/foo',
+        },
+        stubs: ['router-link'],
+      });
+      const actual = wrapper.html();
+      const expected = '<router-link-stub event="click" class="button ripple" to="/foo"> <!----></router-link-stub>';
+
+      expect(actual).toBe(expected);
+    });
+
+    test('renders disabled router-link', () => {
+      const wrapper = mount<any>(VueButton, {
+        localVue,
+        propsData: {
+          as: 'router-link',
+          to: '/foo',
+          disabled: true,
+        },
+        stubs: ['router-link'],
+      });
+      const actual = wrapper.html();
+      const expected =
+        '<router-link-stub disabled="true" class="button ripple disabled" to="/foo"> <!----></router-link-stub>';
+
+      expect(actual).toBe(expected);
+    });
+
+    test('renders a', () => {
+      const wrapper = mount<any>(VueButton, {
+        localVue,
+        propsData: {
+          as: 'a',
+          href: '/foo',
+        },
+      });
+      const actual = wrapper.html();
+      const expected = '<a class="button ripple" href="/foo"> <!----></a>';
+
+      expect(actual).toBe(expected);
+    });
+
+    test('should prevent and stop click event if disabled', () => {
+      const wrapper = mount<any>(VueButton, {
+        localVue,
+        propsData: {
+          as: 'a',
+          href: '/foo',
+          disabled: true,
+        },
+      });
+      const e = {
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+      };
+
+      wrapper.vm.click(e);
+
+      expect(e.preventDefault).toHaveBeenCalled();
+      expect(e.stopPropagation).toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/shared/components/VueButton/VueButton.stories.ts
+++ b/src/app/shared/components/VueButton/VueButton.stories.ts
@@ -5,6 +5,8 @@ import VueButton from './VueButton.vue';
 
 const story = storiesOf('Atoms|Button', module) as any;
 
+story.addDecorator(require('storybook-vue-router').default());
+
 story.add(
   'Button Variants',
   withInfo({})(() => ({
@@ -50,6 +52,33 @@ story.add(
 <vue-button @click="action" color="success" outlined>Success Outlined</vue-button>
 <vue-button @click="action" color="success" ghost>Success Ghost</vue-button>
 <vue-button @click="action" color="success" loading>Success Loading</vue-button>
+</div>
+`,
+    methods: {
+      action: action('@onClick'),
+    },
+  })),
+);
+
+story.add(
+  'Button as Link',
+  withInfo({})(() => ({
+    components: { VueButton },
+    template: `<div>
+Router-Link<br/>
+<vue-button @click="action" as="router-link" color="primary" target="/">Router Link</vue-button>
+<vue-button @click="action" as="router-link" color="primary" target="/" disabled>Router Link</vue-button>
+<vue-button @click="action" as="router-link" color="primary" target="/" outlined>Router Link</vue-button>
+<vue-button @click="action" as="router-link" color="primary" target="/" ghost>Router Link</vue-button>
+<vue-button @click="action" as="router-link" color="primary" target="/" loading>Router Link</vue-button>
+<br/>
+<br/>
+A-Element: <br/>
+<vue-button @click="action" as="a" color="primary" target="/">Router Link</vue-button>
+<vue-button @click="action" as="a" color="primary" target="/" disabled>Router Link</vue-button>
+<vue-button @click="action" as="a" color="primary" target="/" outlined>Router Link</vue-button>
+<vue-button @click="action" as="a" color="primary" target="/" ghost>Router Link</vue-button>
+<vue-button @click="action" as="a" color="primary" target="/" loading>Router Link</vue-button>
 </div>
 `,
     methods: {

--- a/src/app/shared/components/VueButton/VueButton.vue
+++ b/src/app/shared/components/VueButton/VueButton.vue
@@ -1,8 +1,19 @@
 <template>
-  <button :class="cssClasses" :disabled="disabled" @click="click" ref="button" :style="{ width: actualWidth }">
+  <component
+    :is="as"
+    :to="isRouterLink && target"
+    :href="isRegularLink && target"
+    :disabled="disabled"
+    :class="cssClasses"
+    @click="click"
+    @click.native="click"
+    ref="button"
+    :style="{ width: actualWidth }"
+    :event="!isDisabled && isRouterLink ? 'click' : null"
+  >
     <slot v-if="loading === false" />
     <vue-loader :class="$style.loader" v-if="loading === true" />
-  </button>
+  </component>
 </template>
 
 <script lang="ts">
@@ -19,6 +30,13 @@ export default {
     },
     loading: {
       type: Boolean,
+    },
+    as: {
+      type: String,
+      default: 'button',
+    },
+    target: {
+      type: String,
     },
     outlined: {
       type: Boolean,
@@ -52,10 +70,24 @@ export default {
     actualWidth() {
       return this.loading && this.$refs.button ? `${this.$refs.button.getBoundingClientRect().width}px` : null;
     },
+    isDisabled() {
+      return this.disabled || this.loading;
+    },
+    isRouterLink() {
+      return this.as === 'router-link';
+    },
+    isRegularLink() {
+      return this.as === 'a';
+    },
   },
   methods: {
     click(e: Event) {
-      if (!this.disabled && !this.loading) {
+      if (this.isRegularLink && this.isDisabled) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+
+      if (this.isDisabled === false) {
         this.$emit('click', e);
       }
     },
@@ -89,9 +121,15 @@ export default {
   height: $button-height;
   -webkit-tap-highlight-color: transparent;
   user-select: none;
+  text-decoration: $button-text-decoration;
 
   &:active {
     box-shadow: $button-active-shadow;
+    text-decoration: $button-hover-text-decoration;
+  }
+
+  &:hover {
+    text-decoration: $button-hover-text-decoration;
   }
 
   &.disabled,
@@ -150,6 +188,7 @@ export default {
 
   &:hover {
     background: $button-primary-hover-bg;
+    color: $button-primary-hover-color;
   }
 
   :global {
@@ -166,6 +205,7 @@ export default {
 
   &:hover {
     background: $button-secondary-hover-bg;
+    color: $button-secondary-hover-color;
   }
 
   :global {
@@ -182,6 +222,7 @@ export default {
 
   &:hover {
     background: $button-tertiary-hover-bg;
+    color: $button-tertiary-hover-color;
   }
 
   :global {
@@ -198,6 +239,7 @@ export default {
 
   &:hover {
     background: $button-success-hover-bg;
+    color: $button-success-hover-color;
   }
 
   :global {
@@ -214,6 +256,7 @@ export default {
 
   &:hover {
     background: $button-warning-hover-bg;
+    color: $button-warning-hover-color;
   }
 
   :global {
@@ -230,6 +273,7 @@ export default {
 
   &:hover {
     background: $button-danger-hover-bg;
+    color: $button-danger-hover-color;
   }
 
   :global {

--- a/src/app/shared/designSystem/variables/_button.scss
+++ b/src/app/shared/designSystem/variables/_button.scss
@@ -9,35 +9,43 @@ $button-border-radius: $brand-border-radius;
 $button-shadow: none;
 $button-transition: all 300ms cubic-bezier(0.25, 0.8, 0.25, 1);
 $button-active-shadow: 0 12px 20px rgba(0, 0, 0, 0.2), 0 10px 10px rgba(0, 0, 0, 0.18);
+$button-text-decoration: none;
+$button-hover-text-decoration: none;
 
 $button-primary-color: $brand-text-color-inverse;
 $button-primary-bg: $brand-primary;
 $button-primary-hover-bg: darken($button-primary-bg, 5%);
+$button-primary-hover-color: $button-primary-color;
 $button-primary-border: 1px solid $button-primary-bg;
 
 $button-secondary-color: $brand-text-color;
 $button-secondary-bg: $brand-secondary;
 $button-secondary-hover-bg: darken($button-secondary-bg, 5%);
+$button-secondary-hover-color: $button-secondary-color;
 $button-secondary-border: 1px solid $button-secondary-bg;
 
 $button-tertiary-color: $brand-text-color;
 $button-tertiary-bg: $brand-tertiary;
 $button-tertiary-hover-bg: darken($button-tertiary-bg, 5%);
+$button-tertiary-hover-color: $button-tertiary-color;
 $button-tertiary-border: 1px solid $button-tertiary-bg;
 
 $button-danger-color: $brand-text-color;
 $button-danger-bg: $brand-danger;
 $button-danger-hover-bg: darken($button-danger-bg, 5%);
+$button-danger-hover-color: $button-danger-color;
 $button-danger-border: 1px solid $button-danger-bg;
 
 $button-warning-color: $brand-text-color;
 $button-warning-bg: $brand-warning;
 $button-warning-hover-bg: darken($button-warning-bg, 5%);
+$button-warning-hover-color: $button-warning-color;
 $button-warning-border: 1px solid $button-warning-bg;
 
 $button-success-color: $brand-text-color;
 $button-success-bg: $brand-success;
 $button-success-hover-bg: darken($button-success-bg, 5%);
+$button-success-hover-color: $button-success-color;
 $button-success-border: 1px solid $button-success-bg;
 
 $button-outlined-border-width: 0.2rem;


### PR DESCRIPTION
<!--
There are two main goals in this document, depending on the nature of your PR:

- description: please tell us about your PR
- checklist: please review the checklist

To help to quickly understand the nature of your pull request,
please create a description that incorporates the following elements:
-->

### What is accomplished by your PR?
This PR adds the ability to render a link as a button. supported link types:
- `router-link`
- `a`

### Is there something controversial in your PR?
@tamer-mohamed I decided against the generic solution because it ends up with a very ugly markup. The issue is that we have to dynamically bind props and attributes which can end up in a markup like this:

```
<router-link-stub event="click" to="/foo" as="router-link" class="button ripple"> <!----></router-link-stub>
```

I had a look at vuetify, they also provide every single prop instead of a generic solution, should be fine.

### Link to the Issue
no ticket

# Checklist

### New Feature / Bug Fix

- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR
- [ ] Change documentation for the code introduced by your PR
- [x] Add Story / Design System Page for a new component introduced by your PR

<!--
Thanks for contributing!
-->
